### PR TITLE
Added color to "CARET_COLOR" to increase readability

### DIFF
--- a/scheme/Zenburn.xml
+++ b/scheme/Zenburn.xml
@@ -9,7 +9,7 @@
     <option name="CARET_ROW_COLOR" value="333333" />
     <option name="INDENT_GUIDE" value="333333" />
     <option name="LINE_NUMBERS_COLOR" value="8a8a8a" />
-    <option name="RIGHT_MARGIN_COLOR" value="" />
+    <option name="RIGHT_MARGIN_COLOR" value="8a8a8a" />
   </colors>
   <attributes>
     <option name="APACHE_CONFIG.ARG_LEXEM">


### PR DESCRIPTION
Hello negativefix,

i'm using your schema in phpstorm for some time right now. After i've migrate my shell and all available environment to a zenburn schema, i figured out the one tiny thing i would like to improve.
I'm a php developer, so i must write that i'm using your schema in php- and mysqlfiles in general. Hopefully the modified color is the same when dealing with html- or javascriptfiles.
Anyway, i changed the color and if you like it, i can remove my branch and use yours again - as it is intended from my point of view ;-).

Greetings and thanks for the schema,
artodeto
